### PR TITLE
Add 'setter' input to Relay and MergeState blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Commands
 
 Input
 -----
+
+### default
+
 Any list of signals. Each signal will be evaluated against **state_expr** to determine the new *state* of the block for the signal's group.
+
+### setter
+
+Signals passed to this input will always (and only) be used to set the state. They ignore **sate_sig**.
 
 Output
 ------

--- a/merge_state_block.py
+++ b/merge_state_block.py
@@ -1,9 +1,11 @@
 from .state_base_block import StateBase
+from nio.common.block.attribute import Input
 from nio.common.discovery import Discoverable, DiscoverableType
 from nio.metadata.properties import ExpressionProperty
 from nio.metadata.properties import StringProperty
 
 
+@Input('setter')
 @Discoverable(DiscoverableType.block)
 class MergeState(StateBase):
 
@@ -16,7 +18,7 @@ class MergeState(StateBase):
 
     state_name = StringProperty(default='state', title="State Name")
     state_sig = ExpressionProperty(title="Is State Signal",
-                                   default="{{hasattr($, 'state')}}")
+                                   default="{{ hasattr($, 'state') }}")
 
     def _process_group(self, signals, group, to_notify):
         for signal in signals:
@@ -36,3 +38,12 @@ class MergeState(StateBase):
                     "Assigning state {} to signal".format(existing_state))
                 setattr(signal, self.state_name, existing_state)
                 to_notify.append(signal)
+
+    def _process_setter_group(self, signals, group, to_notify):
+        """ Process the signals for a group.
+
+        Add any signals that should be passed through to the to_notify list
+        """
+        for signal in signals:
+            self._logger.debug("Attempting to set state")
+            self._process_state(signal, group)

--- a/relay_block.py
+++ b/relay_block.py
@@ -1,8 +1,10 @@
 from .state_base_block import StateBase
+from nio.common.block.attribute import Input
 from nio.common.discovery import Discoverable, DiscoverableType
 from nio.metadata.properties import ExpressionProperty
 
 
+@Input('setter')
 @Discoverable(DiscoverableType.block)
 class Relay(StateBase):
 
@@ -12,7 +14,7 @@ class Relay(StateBase):
     """
 
     state_sig = ExpressionProperty(
-        title="Is State Signal", default="{{hasattr($, 'state')}}")
+        title="Is State Signal", default="{{ hasattr($, 'state') }}")
 
     def _process_group(self, signals, group, to_notify):
         """ Process the signals for a group.
@@ -35,3 +37,12 @@ class Relay(StateBase):
                 to_notify.append(signal)
             else:
                 self._logger.debug("State is False")
+
+    def _process_setter_group(self, signals, group, to_notify):
+        """ Process the signals for a group.
+
+        Add any signals that should be passed through to the to_notify list
+        """
+        for signal in signals:
+            self._logger.debug("Attempting to set state")
+            self._process_state(signal, group)

--- a/tests/test_merge_state_block.py
+++ b/tests/test_merge_state_block.py
@@ -76,3 +76,25 @@ class TestMergeState(NIOBlockTestCase):
         blk.process_signals([StateSignal('hello')])
         self.assert_num_signals_notified(1, blk)
         self.assertEqual(self._signals[0].state, 1)
+
+    def test_setter_input(self, mock_backup):
+        blk = MergeState()
+        self.configure_block(blk, {
+            # No signals in default input are state setter signals
+            'state_sig': '{{ False }}',
+            'initial_state': '{{False}}',
+            "state_expr": "{{$state}}",
+            'group_by': 'null',
+            "state_name": "mstate"
+        })
+        blk.start()
+        # set state
+        blk.process_signals([StateSignal('1')], input_id='setter')
+        self.assertEqual(blk.get_state('null'), '1')
+        # set state again
+        blk.process_signals([StateSignal('2')], input_id='setter')
+        self.assertEqual(blk.get_state('null'), '2')
+        # no signals were notified
+        self.assert_num_signals_notified(0, blk)
+
+

--- a/tests/test_relay_block.py
+++ b/tests/test_relay_block.py
@@ -64,6 +64,28 @@ class TestRelay(NIOBlockTestCase):
         self.assertEqual(self._signals[0].other, '5')
         blk.stop()
 
+    def test_setter_input(self, mock_backup):
+        blk = Relay()
+        self.configure_block(blk, {
+            # No signals in default input are state setter signals
+            'state_sig': '{{ False }}',
+            'state_expr': '{{$state}}',
+            'initial_state': '{{False}}',
+            'group_by': 'null'
+        })
+        blk.start()
+        self.assertFalse(blk.get_state('null'))
+        # set state to True
+        blk.process_signals([StateSignal('1')], input_id='setter')
+        self.assertEqual(blk.get_state('null'), '1')
+        self.assertTrue(bool(blk.get_state('null')))
+        # set state back to False
+        blk.process_signals([StateSignal('')], input_id='setter')
+        self.assertEqual(blk.get_state('null'), '')
+        self.assertFalse(bool(blk.get_state('null')))
+        # no signals were notified
+        self.assert_num_signals_notified(0, blk)
+
     def test_bad_state_sig(self, mock_backup):
         """ Make sure that a bad state_sig is not a state setter """
         blk = Relay()


### PR DESCRIPTION
It's about time this is added! Probably the most useful multiple input block we could have. 

Note: First time doing multi-input instead of multi-output. The name of the branch was out of habit.