### PR TITLE
Remove state_sig property from blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,19 @@ Commands
 Input
 -----
 
-### default
+### getter (default)
 
-Any list of signals. Each signal will be evaluated against **state_expr** to determine the new *state* of the block for the signal's group.
+Any list of signals. Signal that _get_ a state and/or pass through the block.
 
 ### setter
 
-Signals passed to this input will always (and only) be used to set the state. They ignore **sate_sig**.
+Signals passed to this input set the *state* of the block. Each signal is evaluated against **state_expr** to determine the new *state* of the block for the signal's group.
 
 Output
 ------
 Depends on the individual block
 
-
-------------------
-
+------------------------------------------------------------------------------
 
 StateChange
 ============
@@ -54,7 +52,7 @@ Maintains a *state* and when *state* changes, a signal is notified that containe
 
 
 Additional Properties
----------
+---------------------
 
 -   **exclude**: Select whether you want to exclude other signals. If checked, the only output will be *state* and *prev_state*. If not checked, *state* and *prev_state* will be appended onto the incomming signal.
 
@@ -63,40 +61,27 @@ Output
 ------
 When *state* changes, a signal is notifed with attribues *state*, *prev_state*, and *group*. If exclude is _unchecked_ then the signal that changed the state will have the attributes added to it.
 
-------------------
+------------------------------------------------------------------------------
 
 
 Relay
-============
+=====
 
-If *state_sig* evaluates to True, then it is used to set the *state*. Else, the signal is notified if *state* is True.
-
-- When *state* is True, signals can pass through
-- When *state* is False, signals are blocked
-
-Additional Properties
----------
-
--   **state_sig**: If True, signal is used to set *state*. Else, the signal is notified if *state* is True.
-
+*getter* signals are pass through the block if the last *setter* signal set the state to True. Else, the signals to *getter* are filtered out.
 
 Output
 ------
-When *state* is True, non state-setting signals are output
+When *state* is True, input *getter* signals are output
 
 When *state* is False, no signals are output
 
--------------
+------------------------------------------------------------------------------
 
 MergeState
-============
+==========
 
-Maintains a *state* and merges that state (with name **state_name**) with signals that passes through
+Maintains a *state* and merges that state (with name **state_name**) with signals that are input through the *getter* input.
 
-Additional Properties
----------
-
--   **state_sig**: If True, signal is used to set *state*. Else, the signal is notified and *state* is assigned to the attribute *state_name*.
 -   **state_name**: String property that is the name of the appended *state*
 
 Output

--- a/merge_state_block.py
+++ b/merge_state_block.py
@@ -11,39 +11,29 @@ from nio.metadata.properties import ExpressionProperty, StringProperty, \
 @Discoverable(DiscoverableType.block)
 class MergeState(StateBase):
 
-    """
-    If *state_sig* evaluates to True then the signal sets the state according
-    to *state_expr*. Else, the signal gets assigned the state to the attribute
-    *state_name*.
+    """ Merge the *setter* state into *getter* signals.
 
+    Maintains a *state* and merges that state (with name **state_name**) with
+    signals that are input through the *getter* input.
     """
 
     state_name = StringProperty(default='state', title="State Name")
-    state_sig = ExpressionProperty(title="Is State Signal",
-                                   default="{{ hasattr($, 'state') }}")
-    version = VersionProperty(default='2.0.0', min_version='2.0.0')
+    version = VersionProperty(default='3.0.0')
 
     def _process_group(self, signals, group, to_notify):
-        for signal in signals:
-            try:
-                is_state_sig = self.state_sig(signal)
-            except:
-                is_state_sig = False
-                self._logger.exception("Failed determining state signal")
+        """ Process the signals from the default/getter input for a group.
 
-            # 2 choices - state setter, or trying to pass through
-            if is_state_sig:
-                self._logger.debug("Attempting to set state")
-                self._process_state(signal, group)
-            else:
-                existing_state = self.get_state(group)
-                self._logger.debug(
-                    "Assigning state {} to signal".format(existing_state))
-                setattr(signal, self.state_name, existing_state)
-                to_notify.append(signal)
+        Add any signals that should be passed through to the to_notify list
+        """
+        for signal in signals:
+            existing_state = self.get_state(group)
+            self._logger.debug(
+                "Assigning state {} to signal".format(existing_state))
+            setattr(signal, self.state_name, existing_state)
+            to_notify.append(signal)
 
     def _process_setter_group(self, signals, group, to_notify):
-        """ Process the signals for a group.
+        """ Process the signals from the setter input for a group.
 
         Add any signals that should be passed through to the to_notify list
         """

--- a/relay_block.py
+++ b/relay_block.py
@@ -11,39 +11,27 @@ from nio.metadata.properties import ExpressionProperty, VersionProperty
 @Discoverable(DiscoverableType.block)
 class Relay(StateBase):
 
-    """
-    If *state_sig* evaluates to True then the signal sets the state according
-    to *state_expr*. Else, the signal gets notified if the *state* is True.
-    """
+    """ Passthrough *getter* signals if the state is True.
 
-    state_sig = ExpressionProperty(
-        title="Is State Signal", default="{{ hasattr($, 'state') }}")
-    version = VersionProperty(default='2.0.0', min_version='2.0.0')
+    *getter* signals are pass through the block if the last *setter* signal set
+    the state to True. Else, the signals to *getter* are filtered out.
+    """
+    version = VersionProperty(default='3.0.0')
 
     def _process_group(self, signals, group, to_notify):
-        """ Process the signals for a group.
+        """ Process the signals from the default/getter input for a group.
 
         Add any signals that should be passed through to the to_notify list
         """
         for signal in signals:
-            try:
-                is_state_sig = self.state_sig(signal)
-            except:
-                is_state_sig = False
-                self._logger.exception("Failed determining state signal")
-
-            # 3 choices - state setter, state is true, or state is false
-            if is_state_sig:
-                self._logger.debug("Attempting to set state")
-                self._process_state(signal, group)
-            elif self.get_state(group):
+            if self.get_state(group):
                 self._logger.debug("State is True")
                 to_notify.append(signal)
             else:
                 self._logger.debug("State is False")
 
     def _process_setter_group(self, signals, group, to_notify):
-        """ Process the signals for a group.
+        """ Process the signals from the setter input for a group.
 
         Add any signals that should be passed through to the to_notify list
         """


### PR DESCRIPTION
The Relay and MergeState blocks no longer need this state_sig
property. It was orignally put in place from way back before
n.io had the ability to have two different inputs on a block.